### PR TITLE
Bugfix get logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ exports.importJobs = require('./lib/importJobs');
 exports.integrations = require('./lib/integrations');
 exports.oauth = require('./lib/oauth');
 exports.onCall = require('./lib/onCall');
+exports.onCallSummary = require('./lib/onCallSummary');
 exports.people = require('./lib/people');
 exports.planConstants = require('./lib/planConstants');
 exports.planEndpoints = require('./lib/planEndpoints');

--- a/lib/common.js
+++ b/lib/common.js
@@ -216,6 +216,9 @@ async function getMany(
 
   //pull data array from res
   let list = body.data;
+  if(label == 'On Call Summary'){
+    list = body;
+  }
 
   const queue = requestList(body.total, auth, uri, throwError, proxy, timeout); //queue request for records > 100
 

--- a/lib/integrations.js
+++ b/lib/integrations.js
@@ -59,7 +59,7 @@ async function getMany(env, query, planId) {
 async function getLogs(env, query, integrationId) {
   return common.getMany(
     env,
-    `/api/xm/1/integrations/${encodeURIComponent(integrationId)}`,
+    `/api/xm/1/integrations/${encodeURIComponent(integrationId)}/logs`,
     query,
     'Integration Logs'
   );

--- a/lib/onCallSummary.js
+++ b/lib/onCallSummary.js
@@ -1,0 +1,23 @@
+const common = require('./common');
+
+/**
+ * A module related to xMatters on-call information.<br><br>
+ * {@link https://help.xmatters.com/xmapi/index.html#get-on-call-summary}
+ *
+ * @module onCallSummary
+ */
+
+/**
+ * Returns the active members of a group in their order of escalation for each shift. The maximum number of returned results per request is 1000.<br><br>
+ *
+ * {@link https://help.xmatters.com/xmapi/index.html#get-on-call-summary}
+ *
+ * @param {module:environments.xMattersEnvironment} env The xmtoolbox representation of an xMatters instance.
+ * @param {Object} query A json object representing the query string parameters for this request.
+ * @returns {Promise<OnCallSummary[]>} Array of On Call Sumary Objects Requested
+ */
+async function getMany(env, query) {
+  return common.getMany(env, '/api/xm/1/on-call-summary/', query, 'On Call Summary');
+}
+
+exports.getMany = getMany;


### PR DESCRIPTION
This adds `/logs` onto the end of the path used in the `getLogs` method in the `integrations.js` file. A user found this and filed an issue. We should work on getting this deployed to NPM in a new xmtb build ASAP