### PR TITLE
Changing sync options on plans to filter out system workflows

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -258,7 +258,7 @@ function DefaultSyncOptions() {
     peopleFilter: undefined,
 
     plans: false,
-    plansQuery: { embed: 'creator,constants,endpoints,forms,propertyDefinitions,integrations' },
+    plansQuery: { embed: 'creator,constants,endpoints,forms,propertyDefinitions,integrations', planType: "PLAN" },
     plansFilter: undefined,
 
     planConstants: false,


### PR DESCRIPTION
Fix for syncing of anything that relies on plans. Currently, system workflows are returned when getting all plans and that causes issues.